### PR TITLE
[FEAT] 랭킹 페이지 api 구현(칸의 수, 영역의 수 기준)

### DIFF
--- a/src/main/java/com/dnd/ground/domain/user/controller/UserController.java
+++ b/src/main/java/com/dnd/ground/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.dnd.ground.domain.user.controller;
 
+import com.dnd.ground.domain.user.dto.RankResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -7,9 +8,13 @@ import org.springframework.web.bind.annotation.RequestParam;
  * @description 메인홈 구성 컨트롤러 인터페이스
  * @author  박세헌
  * @since   2022-08-02
- * @updated 2022-08-02 / 홈화면 구성 : 박세헌
+ * @updated 2022-08-09 / 랭킹 조회 함수 추가 : 박세헌
  */
 
 public interface UserController {
     ResponseEntity<?> home(@RequestParam("nickName") String nickName);
+
+    ResponseEntity<RankResponseDto.matrixRankingResponseDto> matrixRank(@RequestParam("nickname") String nickName);
+
+    ResponseEntity<RankResponseDto.areaRankingResponseDto> areaRank(@RequestParam("nickName") String nickName);
 }

--- a/src/main/java/com/dnd/ground/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/user/controller/UserControllerImpl.java
@@ -1,6 +1,7 @@
 package com.dnd.ground.domain.user.controller;
 
 import com.dnd.ground.domain.user.dto.HomeResponseDto;
+import com.dnd.ground.domain.user.dto.RankResponseDto;
 import com.dnd.ground.domain.user.service.UserService;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @description 메인홈 구성 컨트롤러 클래스
  * @author  박세헌
  * @since   2022-08-02
- * @updated 2022-08-05 / 홈화면 api 명세 추가 : 박세헌
+ * @updated 2022-08-09 / 랭킹 조회 api 추가: 박세헌
  */
 
 @Api(tags = "유저")
@@ -36,4 +37,17 @@ public class UserControllerImpl implements UserController {
     public ResponseEntity<HomeResponseDto> home(@RequestParam("nickname") String nickName){
         return ResponseEntity.ok(userService.showHome(nickName));
     }
+
+    @Operation(summary = "칸의 수 랭킹", description = "칸의 수가 높은 순서대로 유저들을 조회")
+    @GetMapping("/rank/matrix")
+    public ResponseEntity<RankResponseDto.matrixRankingResponseDto> matrixRank(@RequestParam("nickname") String nickName){
+        return ResponseEntity.ok(userService.matrixRanking(nickName));
+    }
+
+    @Operation(summary = "영역의 수 랭킹", description = "영역의 수가 높은 순서대로 유저들을 조회")
+    @GetMapping("/rank/area")
+    public ResponseEntity<RankResponseDto.areaRankingResponseDto> areaRank(@RequestParam("nickname") String nickName){
+        return ResponseEntity.ok(userService.areaRanking(nickName));
+    }
+
 }

--- a/src/main/java/com/dnd/ground/domain/user/dto/HomeResponseDto.java
+++ b/src/main/java/com/dnd/ground/domain/user/dto/HomeResponseDto.java
@@ -10,12 +10,9 @@ import java.util.*;
 
 /**
  * @description 홈화면 구성 Response Dto
- *              1. 유저 매트릭스 및 정보
- *              2. 챌린지 안하는 친구들 매트릭스
- *              3. 챌린지 하는 친구들 매트릭스 및 정보
  * @author  박세헌
  * @since   2022-08-02
- * @updated 2022-08-08 / UserResponseDto로 한번에 관리 : 박세헌
+ * @updated 2022-08-09 / UserResponseDto로 한번에 관리 : 박세헌
  */
 
 @Data @Builder

--- a/src/main/java/com/dnd/ground/domain/user/dto/RankResponseDto.java
+++ b/src/main/java/com/dnd/ground/domain/user/dto/RankResponseDto.java
@@ -1,0 +1,34 @@
+package com.dnd.ground.domain.user.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @description 랭킹 Response Dto
+ * @author  박세헌
+ * @since   2022-08-08
+ * @updated 2022-08-09 / 랭킹에 관한 dto 생성 : 박세헌
+ */
+
+@Data
+public class RankResponseDto {
+
+    @Data
+    @AllArgsConstructor
+    public static class matrixRankingResponseDto{
+        @ApiModelProperty(value="누적 영역의 수를 기준 내림차순으로 유저들을 정렬", required = true)
+        List<UserResponseDto.matrixRanking> matrixRankings = new ArrayList<>();
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class areaRankingResponseDto{
+        @ApiModelProperty(value="누적 칸의 수를 기준 내림차순으로 유저들을 정렬", required = true)
+        List<UserResponseDto.areaRanking> areaRankings = new ArrayList<>();
+    }
+
+}

--- a/src/main/java/com/dnd/ground/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/dnd/ground/domain/user/dto/UserResponseDto.java
@@ -5,17 +5,21 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
  * @description 유저 Response Dto
- *              1. 유저 매트릭스 및 정보
- *              2. 챌린지 안하는 친구들 매트릭스
- *              3. 챌린지 하는 친구들 매트릭스 및 정보
+ *              1. 유저(나) 매트릭스 및 정보
+ *              2. 나와 챌린지 안하는 친구들 매트릭스
+ *              3. 나와 챌린지 하는 친구들 매트릭스 및 정보
+ *              4. 누적 칸의 수에 대한 랭킹 정보
+ *  *           5. 누적 영역의 수에 대한 랭킹 정보
  * @author  박세헌
  * @since   2022-08-08
- * @updated 2022-08-08 / UserResponseDto 생성 : 박세헌
+ * @updated 2022-08-09 / 랭킹에 관한 dto 생성 : 박세헌
  */
 
 @Data
@@ -52,6 +56,25 @@ public class UserResponseDto {
 
         @ApiModelProperty(value = "칸 꼭지점 위도, 경도 리스트", required = true)
         public Set<MatrixSetDto> matrices = new HashSet<>();
+    }
 
+    @Data
+    @AllArgsConstructor
+    public static class matrixRanking{
+        @ApiModelProperty(value = "닉네임", example = "NickA", required = true)
+        private String nickname;
+
+        @ApiModelProperty(value = "누적 칸의 수", example = "누적 칸의 수", required = true)
+        private Integer matrixNumber;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class areaRanking{
+        @ApiModelProperty(value = "닉네임", example = "NickA", required = true)
+        private String nickname;
+
+        @ApiModelProperty(value = "누적 영역의 수", example = "누적 영역의 수", required = true)
+        private Integer areaNumber;
     }
 }

--- a/src/main/java/com/dnd/ground/domain/user/service/UserService.java
+++ b/src/main/java/com/dnd/ground/domain/user/service/UserService.java
@@ -2,15 +2,18 @@ package com.dnd.ground.domain.user.service;
 
 import com.dnd.ground.domain.user.User;
 import com.dnd.ground.domain.user.dto.HomeResponseDto;
+import com.dnd.ground.domain.user.dto.RankResponseDto;
 
 /**
  * @description 유저 서비스 인터페이스
  * @author  박세헌, 박찬호
  * @since   2022-08-01
- * @updated 2022-08-04 / 홈 화면 구성 로직: 박세헌
+ * @updated 2022-08-09 / 랭킹 관련 함수 추가: 박세헌
  */
 
 public interface UserService {
     User save(User user);
     HomeResponseDto showHome(String nickname);
+    RankResponseDto.matrixRankingResponseDto matrixRanking(String nickname);
+    RankResponseDto.areaRankingResponseDto areaRanking(String nickname);
 }


### PR DESCRIPTION
1. 칸의 수 기준 내림차순으로 정렬하여 유저 조회
2. 영역의 수 기준 내림차순으로 정렬하여 유저 조회
